### PR TITLE
Update/Fix Docusign Quickstart PHP to use docusign/esign-client v4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "docusign/esign-client": "^3.0"
+        "docusign/esign-client": "^4.0"
     }
 }

--- a/qs-01-php-embed-signing-ceremony.php
+++ b/qs-01-php-embed-signing-ceremony.php
@@ -88,7 +88,7 @@ function embedded_signing_ceremony(){
     $config = new DocuSign\eSign\Configuration();
     $config->setHost($basePath);
     $config->addDefaultHeader("Authorization", "Bearer " . $accessToken);
-    $apiClient = new DocuSign\eSign\ApiClient($config);
+    $apiClient = new DocuSign\eSign\Client\ApiClient($config);
     $envelopeApi = new DocuSign\eSign\Api\EnvelopesApi($apiClient);
     $results = $envelopeApi->createEnvelope($accountId, $envelopeDefinition);
     $envelopeId = $results['envelope_id'];
@@ -131,7 +131,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
         header('Location: ' . $redirectUrl);
     } catch (Exception $e) {
         echo 'Caught exception: ',  $e->getMessage(), "\n";
-        if ($e instanceof DocuSign\eSign\ApiException) {
+        if ($e instanceof DocuSign\eSign\Client\ApiException) {
             print ("\nDocuSign API error information: \n");
             var_dump ($e->getResponseBody());
         }

--- a/qs-02-php-send-envelope.php
+++ b/qs-02-php-send-envelope.php
@@ -78,7 +78,7 @@ function send_document_for_signing(){
     $config = new DocuSign\eSign\Configuration();
     $config->setHost($basePath);
     $config->addDefaultHeader("Authorization", "Bearer " . $accessToken);
-    $apiClient = new DocuSign\eSign\ApiClient($config);
+    $apiClient = new DocuSign\eSign\Client\ApiClient($config);
     $envelopeApi = new DocuSign\eSign\Api\EnvelopesApi($apiClient);
     $results = $envelopeApi->createEnvelope($accountId, $envelopeDefinition);
     return $results;
@@ -98,7 +98,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
         <?php
     } catch (Exception $e) {
         echo 'Caught exception: ',  $e->getMessage(), "\n";
-        if ($e instanceof DocuSign\eSign\ApiException) {
+        if ($e instanceof DocuSign\eSign\Client\ApiException) {
             print ("\nDocuSign API error information: \n");
             var_dump ($e->getResponseBody());
         }

--- a/qs-03-php-list-envelopes.php
+++ b/qs-03-php-list-envelopes.php
@@ -24,7 +24,7 @@ function list_envelopes(){
     $config = new DocuSign\eSign\Configuration();
     $config->setHost($basePath);
     $config->addDefaultHeader("Authorization", "Bearer " . $accessToken);
-    $apiClient = new DocuSign\eSign\ApiClient($config);
+    $apiClient = new DocuSign\eSign\Client\ApiClient($config);
     $envelopeApi = new DocuSign\eSign\Api\EnvelopesApi($apiClient);
 
     #
@@ -55,7 +55,7 @@ try {
     <?php
 } catch (Exception $e) {
     echo 'Caught exception: ',  $e->getMessage(), "\n";
-    if ($e instanceof DocuSign\eSign\ApiException) {
+    if ($e instanceof DocuSign\eSign\Client\ApiException) {
         print ("\nDocuSign API error information: \n");
         var_dump ($e->getResponseBody());
     }


### PR DESCRIPTION
Fix for commit [33618d9](https://github.com/docusign/docusign-php-client/commit/33618d9556fcf327eeb1fe37f9db3e7a02a7fd4e#diff-c8c89447ae6e1889e9afc2ed1471a443) to docusign-php-client

Current installation instructions in README.md will install esign-client v4.0 and current qs example files will give "Class not found" errors for ApiClient & ApiException classes