### PR TITLE
Update qs-02-php-send-envelope.php

### DIFF
--- a/qs-02-php-send-envelope.php
+++ b/qs-02-php-send-envelope.php
@@ -107,7 +107,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 }
 # Since it isn't a POST, print the form:
 ?>
-<html lang="en">
+<html>
     <body>
         <form method="post">
             <input type="submit" value="Send document signature request!"


### PR DESCRIPTION
in order to run on apache, "en" at html tag is no-needed.
if it has,apache misunderstand this document is text/plain. 